### PR TITLE
fix: add nofollow to outbound links to sites

### DIFF
--- a/dashboard/app/pages/hits/[domain].vue
+++ b/dashboard/app/pages/hits/[domain].vue
@@ -15,6 +15,9 @@ useHead({
     const v = data.value?.version ? ` (v${data.value.version})` : ''
     return `${domain.value}${v} — nuxt.fyi`
   },
+  meta: [
+    { name: 'robots', content: 'nofollow' }
+  ]
 })
 
 const CHANNEL_ORDER: Record<string, number> = { discord: 0, bluesky: 1 }

--- a/dashboard/app/pages/hits/[domain].vue
+++ b/dashboard/app/pages/hits/[domain].vue
@@ -52,7 +52,7 @@ const backTo = computed<RouteLocationRaw>(() => {
       </h1>
       <p v-if="data.title" class="muted">{{ data.title }}</p>
       <p>
-        <a :href="data.finalUrl || `https://${data.domain}`" target="_blank" rel="noopener">
+        <a :href="data.finalUrl || `https://${data.domain}`" target="_blank" rel="nofollow noopener">
           {{ data.finalUrl || `https://${data.domain}` }}<span class="sr-only"> (opens in a new tab)</span>
         </a>
       </p>


### PR DESCRIPTION
Law of the internet, no feet pics for free, no link juice for free (on user generated content)

There's other places to make this fix, like page wide or robot.txt to not crawl, but this is the most targetted and should likely happen even if the others do. So no spammer detects "outbound link w/ dofollow"